### PR TITLE
Add .dockerignore file

### DIFF
--- a/signal/.dockerignore
+++ b/signal/.dockerignore
@@ -1,0 +1,5 @@
+# Start by ignoring everything.
+**
+
+# Explicitly add the things we need.
+!/root

--- a/signal/config.json
+++ b/signal/config.json
@@ -27,5 +27,5 @@
   },
   "slug": "signal",
   "startup": "before",
-  "version": "10.0.0"
+  "version": "10.0.1"
 }


### PR DESCRIPTION
This does the right thing in terms of security/minimal image. But it does make debugging/prototyping stuff harder. If you forget this exists, and add something to the dockerfile, you'll get some weird errors.

Closes #3 