### PR TITLE
Create services.yaml

### DIFF
--- a/signal/signalmessenger/services.yaml
+++ b/signal/signalmessenger/services.yaml
@@ -1,0 +1,1 @@
+# empty, as user defines name of service


### PR DESCRIPTION
Integrations now need to provide a `services.yaml` and Home Assistant will issue a warning if none is present. The mere existence of this file will avoid this warning. 

As the provided service of this integration can be renamed in the configuration, it is not necessary to specify the service in this file.

Related:
https://github.com/home-assistant/core/issues/27289