### PR TITLE
Make files shareable between add-ons

### DIFF
--- a/signal/config.json
+++ b/signal/config.json
@@ -12,6 +12,7 @@
     "/dev/urandom"
   ],
   "map": [
+    "share:rw",
     "config:rw"
   ],
   "name": "Signal",


### PR DESCRIPTION
Mount "share" inside container to make it easier to send camera snapshots.