### PR TITLE
Update to signal-cli 0.11.2

### DIFF
--- a/signal/Dockerfile
+++ b/signal/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=homeassistant/amd64-base-debian:bullseye
 FROM $BUILD_FROM
 
-ENV SIGNAL_VERSION=0.10.8 \
+ENV SIGNAL_VERSION=0.11.2 \
     LIBSIGNAL_VERSION=0.17.0 \
     LANG=C.UTF-8
 


### PR DESCRIPTION
Fixes issue #45 

signal-cli versions below 0.11.2 are completely broken now. This addon is completely dead until signal-cli is updated. 

Please merge and do a new release as soon as possible. @MichaelBitard 

Thanks!