### PR TITLE
GitHub Action to Build libsignal for x86-64, arm64, and armv7

### DIFF
--- a/.github/workflows/build-libsignal.yml
+++ b/.github/workflows/build-libsignal.yml
@@ -1,0 +1,125 @@
+name: build-libsignal
+
+on: workflow_dispatch
+
+env:
+  LIBSIGNAL_VERSION: '0.20.0'
+
+jobs:
+  build-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          wget https://github.com/signalapp/libsignal/archive/refs/tags/v${{ env.LIBSIGNAL_VERSION }}.zip
+          unzip v${{ env.LIBSIGNAL_VERSION }}.zip
+          cd libsignal-${{ env.LIBSIGNAL_VERSION }}
+          cargo build -p libsignal-jni --release
+          mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}
+          mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/x86-64
+          cp /home/runner/work/hassio-addons/hassio-addons/libsignal-${{ env.LIBSIGNAL_VERSION }}/target/release/libsignal_jni.so /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/x86-64/libsignal_jni.so
+          rm -rf /home/runner/work/hassio-addons/hassio-addons/libsignal-${{ env.LIBSIGNAL_VERSION }}
+          rm /home/runner/work/hassio-addons/hassio-addons/v${{ env.LIBSIGNAL_VERSION }}.zip
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+  build-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 10240
+          swap-size-mb: 30720
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+      - run: |
+          echo "Free space:"
+          df -h
+      - run: |
+          mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}
+          mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/arm64
+          wget https://github.com/signalapp/libsignal/archive/refs/tags/v${{ env.LIBSIGNAL_VERSION }}.zip
+          unzip v${{ env.LIBSIGNAL_VERSION }}.zip
+          cd libsignal-${{ env.LIBSIGNAL_VERSION }}
+          mkdir -p .cargo
+          CARGO_HOME=$PWD/cargo cargo vendor vendor > .cargo/config.toml
+          cat .cargo/config.toml
+      - uses: pguyot/arm-runner-action@v2
+        with:
+          base_image: dietpi:rpi_armv8_bullseye
+          cpu: cortex-a53
+          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
+          image_additional_mb: 8192
+          shell: /bin/bash
+          bind_mount_repository: true
+          commands: |
+              test `uname -m` = aarch64
+              grep Model /proc/cpuinfo
+              free -h
+              swapon -s
+              apt update -y
+              apt install -y clang libclang-dev cmake make libprotobuf-dev protobuf-compiler
+              curl https://sh.rustup.rs -sSf | sh -s -- -y
+              source "$HOME/.cargo/env"
+              cd libsignal-${{ env.LIBSIGNAL_VERSION }}
+              cargo build --jobs 1 -p libsignal-jni --release --offline
+              cp libsignal-${{ env.LIBSIGNAL_VERSION }}/target/release/libsignal_jni.so ../signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/arm64/libsignal_jni.so
+              cd ..
+              rm -rf libsignal-${{ env.LIBSIGNAL_VERSION }}
+              rm v${{ env.LIBSIGNAL_VERSION }}.zip
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+  build-armv7:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 10240
+          swap-size-mb: 30720
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+      - run: |
+          echo "Free space:"
+          df -h
+      - run: |
+          mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}
+          mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/armv7
+          wget https://github.com/signalapp/libsignal/archive/refs/tags/v${{ env.LIBSIGNAL_VERSION }}.zip
+          unzip v${{ env.LIBSIGNAL_VERSION }}.zip
+          cd libsignal-${{ env.LIBSIGNAL_VERSION }}
+          mkdir -p .cargo
+          CARGO_HOME=$PWD/cargo cargo vendor vendor > .cargo/config.toml
+          cat .cargo/config.toml
+      - uses: pguyot/arm-runner-action@v2
+        with:
+          base_image: dietpi:rpi_armv7_bullseye
+          cpu: cortex-a7
+          cpu_info: cpuinfo/raspberrypi_3b
+          image_additional_mb: 8192
+          shell: /bin/bash
+          bind_mount_repository: true
+          commands: |
+              test `uname -m` = armv7l
+              grep Model /proc/cpuinfo
+              free -h
+              swapon -s
+              apt update -y
+              apt install -y clang libclang-dev cmake make libprotobuf-dev protobuf-compiler
+              curl https://sh.rustup.rs -sSf | sh -s -- -y
+              source "$HOME/.cargo/env"
+              cd libsignal-${{ env.LIBSIGNAL_VERSION }}
+              CARGO_HOME=$PWD/cargo cargo build --jobs 1 -p libsignal-jni --release --offline
+              cp libsignal-${{ env.LIBSIGNAL_VERSION }}/target/release/libsignal_jni.so ../signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/armv7/libsignal_jni.so
+              cd ..
+              rm -rf libsignal-${{ env.LIBSIGNAL_VERSION }}
+              rm v${{ env.LIBSIGNAL_VERSION }}.zip
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions

--- a/.github/workflows/build-libsignal.yml
+++ b/.github/workflows/build-libsignal.yml
@@ -4,6 +4,7 @@ on: workflow_dispatch
 
 env:
   LIBSIGNAL_VERSION: '0.20.0'
+  GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:
   build-x86_64:

--- a/.github/workflows/build-libsignal.yml
+++ b/.github/workflows/build-libsignal.yml
@@ -27,7 +27,6 @@ jobs:
   build-arm64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -39,6 +38,7 @@ jobs:
       - run: |
           echo "Free space:"
           df -h
+      - uses: actions/checkout@v3
       - run: |
           mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}
           mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/arm64
@@ -77,7 +77,6 @@ jobs:
   build-armv7:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -89,6 +88,7 @@ jobs:
       - run: |
           echo "Free space:"
           df -h
+      - uses: actions/checkout@v3
       - run: |
           mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}
           mkdir -p /home/runner/work/hassio-addons/hassio-addons/signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/armv7

--- a/.github/workflows/build-libsignal.yml
+++ b/.github/workflows/build-libsignal.yml
@@ -66,7 +66,7 @@ jobs:
               source "$HOME/.cargo/env"
               cd libsignal-${{ env.LIBSIGNAL_VERSION }}
               cargo build --jobs 1 -p libsignal-jni --release --offline
-              cp libsignal-${{ env.LIBSIGNAL_VERSION }}/target/release/libsignal_jni.so ../signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/arm64/libsignal_jni.so
+              cp ./target/release/libsignal_jni.so ../signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/arm64/libsignal_jni.so
               cd ..
               rm -rf libsignal-${{ env.LIBSIGNAL_VERSION }}
               rm v${{ env.LIBSIGNAL_VERSION }}.zip
@@ -116,7 +116,7 @@ jobs:
               source "$HOME/.cargo/env"
               cd libsignal-${{ env.LIBSIGNAL_VERSION }}
               CARGO_HOME=$PWD/cargo cargo build --jobs 1 -p libsignal-jni --release --offline
-              cp libsignal-${{ env.LIBSIGNAL_VERSION }}/target/release/libsignal_jni.so ../signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/armv7/libsignal_jni.so
+              cp ./target/release/libsignal_jni.so ../signal/root/ext/libraries/libsignal-client/v${{ env.LIBSIGNAL_VERSION }}/armv7/libsignal_jni.so
               cd ..
               rm -rf libsignal-${{ env.LIBSIGNAL_VERSION }}
               rm v${{ env.LIBSIGNAL_VERSION }}.zip


### PR DESCRIPTION
After a lot of trial and error I finally got all of this working. This is an action triggered on workflow_dispatch so it only runs when requested. Editing `LIBSIGNAL_VERSION` will download and compile that version for all 3 architectures. 

**x86_64**
Nothing special here, this is compiled normally using cargo and the resulting binary is copied to the repo and committed. 

**arm64 & armv7**
Both of these are compiled natively under their respective architectures using qemu virtualization. This avoids the cross compiling issues that this project and others were previously facing while trying to cross compile libsignal for various arm architectures. Note that in these jobs the sources of dependencies are downloaded and vendored ahead of time before we jump into qemu virtualization for two reasons:

1. This is much more performant, as resolving and downloading dependencies and updating the cargo indexes is **much** faster outside of virtualization.
2. [Qemu has a bug](https://github.com/rust-lang/cargo/issues/8719) when virtualizing 32-bit architectures on 64-bit hosts that prevents cargo from downloading **any** dependencies. Therefore it is impossible to simply do `cargo build` while virtualizing armv7. 

Therefore we use `cargo vendor` to resolve and download all of the dependencies into the source directory before jumping into virtualization to install rust and do the compiling itself in cargo's offline mode. Finally, we copy the resulting binary and commit it. 